### PR TITLE
Add `layout: default` to YAML front matter of files, so Jekyll parses them properly

### DIFF
--- a/irchelp/allfaqs.md
+++ b/irchelp/allfaqs.md
@@ -1,6 +1,7 @@
 ---
 title: All Frequently Asked Questions
 author: IRCHelp.org
+layout: default
 ---
 
 # IRC Frequently Asked Questions (FAQ) and Help Files

--- a/irchelp/altircfaq.md
+++ b/irchelp/altircfaq.md
@@ -2,6 +2,7 @@
 title: alt.irc faq
 author: alt.irc
 summary: The FAQ from the Usenet group alt.irc
+layout: default
 ---
 
 

--- a/irchelp/authoring.md
+++ b/irchelp/authoring.md
@@ -1,6 +1,7 @@
 ---
 title: www.irchelp.org content guidelines and authoring information.
 author: Stephanie Daugherty
+layout: default
 ---
 
 # Authoring Documents for www.irchelp.org

--- a/irchelp/boilerplate.md
+++ b/irchelp/boilerplate.md
@@ -4,6 +4,7 @@ author: irchelpers
 datecreated: 1 September 1993
 datechanged: 21 December 2012
 summary: this is a summary
+layout: default
 ---
 
 # Introduction

--- a/irchelp/changuide.md
+++ b/irchelp/changuide.md
@@ -3,6 +3,7 @@ title: The New IRC Channel Operator's Guide
 author: Jolo, prysm, and RuyDuck of EFnet #IRChelp
 datechanged: 18 August 2008
 summary:  A guide for those finding themselves as channel operators in EFNet (or other networks without services) for the first time.
+layout: default
 ---
 
 

--- a/irchelp/chanlist/index.md
+++ b/irchelp/chanlist/index.md
@@ -1,5 +1,6 @@
 ---
 title: IRC Channel Lists
+layout: default
 ---
 
 # IRC Channel Lists

--- a/irchelp/clients/cross/chatzilla.md
+++ b/irchelp/clients/cross/chatzilla.md
@@ -2,6 +2,7 @@
 title: Chatzilla
 author: Stephanie Daugherty
 summary: ChatZilla cross-platform IRC client.
+layout: default
 ---
 
 # ChatZilla

--- a/irchelp/clients/cross/index.md
+++ b/irchelp/clients/cross/index.md
@@ -1,5 +1,6 @@
 ---
 title: Cross-platform IRC clients.
+layout: default
 ---
 # Cross-platform IRC clients
 

--- a/irchelp/clients/cross/jircii.md
+++ b/irchelp/clients/cross/jircii.md
@@ -1,5 +1,6 @@
 ---
 title: jIRCii
+layout: default
 ---
 # jIRCii
 

--- a/irchelp/clients/cross/leafchat.md
+++ b/irchelp/clients/cross/leafchat.md
@@ -1,5 +1,6 @@
 ---
 title: LeafChat
+layout: default
 ---
 
 ## Overview

--- a/irchelp/clients/index.md
+++ b/irchelp/clients/index.md
@@ -1,5 +1,6 @@
 ---
 title: IRC Client Directory
+layout: default
 ---
 
 #IRC Clients

--- a/irchelp/clients/mac/colloquy.md
+++ b/irchelp/clients/mac/colloquy.md
@@ -1,5 +1,6 @@
 ---
 title: Colloquy
+layout: default
 ---
 
 **Colloquy 2.x** &nbsp_place_holder; [ [ home page](http://colloquy.info/) | [screen cap](http://colloquy.info/screenshots.html) ]

--- a/irchelp/clients/mac/index.md
+++ b/irchelp/clients/mac/index.md
@@ -3,6 +3,7 @@ title: Mac IRC Clients
 author: Joseph Lo aka Jolo
 dateupdated: 08 May 2013
 summary: IRC Clients for Apple Mac OS X
+layout: default
 ---
 [![*](/media/macappstore_icon.jpg) ](http://www.apple.com/)
 

--- a/irchelp/clients/mac/instantmessage.md
+++ b/irchelp/clients/mac/instantmessage.md
@@ -1,5 +1,6 @@
 ---
 title: Instant Messaging Programs on MacOS X with IRC Support
+layout: default
 ---
 
 # Instant Messaging programs on MacOS X

--- a/irchelp/clients/mac/ircle_setup.md
+++ b/irchelp/clients/mac/ircle_setup.md
@@ -1,6 +1,7 @@
 ---
 title: ircle setup guide
 author: Joseph Lo (jolo)
+layout: default
 ---
 #  ![*](/irchelp/Pix/ircle_spin.gif) Ircle Setup Guide
 ![*](/irchelp/Pix/ircle_spin.gif)

--- a/irchelp/clients/mac/snak.md
+++ b/irchelp/clients/mac/snak.md
@@ -1,5 +1,6 @@
 ---
 title: Snak
+layout: default
 ---
 
 [ ![*](snak.jpg)](http://www.snak.com/Snak.html)

--- a/irchelp/clients/mac/textual.md
+++ b/irchelp/clients/mac/textual.md
@@ -1,5 +1,6 @@
 ---
 title: Textual
+layout: default
 ---
 
 ## Overview

--- a/irchelp/clients/misc/bitlbee.md
+++ b/irchelp/clients/misc/bitlbee.md
@@ -1,5 +1,6 @@
 ---
 title: bitlbee connecting IRC clients to other chat protocols
+layout: default
 ---
 
 # bitlbee: connecting IRC clients to other chat protocols

--- a/irchelp/clients/misc/index.md
+++ b/irchelp/clients/misc/index.md
@@ -2,6 +2,7 @@
 title: Specialized Clients - Bots, Bouncers, and everything else.
 author: Stephanie Daugherty
 summary: Information on special-purpose IRC clients, such as bots and bouncers.
+layout: default
 ---
 
 # Specialized Clients - Bots, Bouncers, and everything else

--- a/irchelp/clients/mobile/index.md
+++ b/irchelp/clients/mobile/index.md
@@ -2,6 +2,7 @@
 title: IRC Clients for Mobile Devices
 author: Stephanie Daugherty
 summary: IRC clients are available for a number of mobile devices, including smartphones, mp3 players, and tablets.
+layout: default
 ---
 
 * [Android](android/)

--- a/irchelp/clients/otheros/index.md
+++ b/irchelp/clients/otheros/index.md
@@ -1,5 +1,6 @@
 ---
 title: IRC Clients for Other Desktop Operating Systems
+layout: default
 ---
 # IRC Clients for Other Operating Systems
 

--- a/irchelp/clients/reviewing/index.md
+++ b/irchelp/clients/reviewing/index.md
@@ -2,6 +2,7 @@
 title: www.irchelp.org IRC client review guide
 author: jolo, stephanie
 summary: Objective guidelines for evaluating IRC clients.
+layout: default
 ---
 
 *This is an ancient draft, started by jolo in the late 90's of how to evaluate IRC clients. It's in the process of being updated, and will be the basis of how we review IRC clients for listing on our website.*

--- a/irchelp/clients/unix/bitchx.md
+++ b/irchelp/clients/unix/bitchx.md
@@ -1,5 +1,6 @@
 ---
 title: BitchX
+layout: default
 ---
 
 # Critical Warning

--- a/irchelp/clients/unix/epic.md
+++ b/irchelp/clients/unix/epic.md
@@ -2,6 +2,7 @@
 title: epic
 author: Stephanie Daugherty
 summary: Information about epic
+layout: default
 ---
 
 # EPIC

--- a/irchelp/clients/unix/erc.md
+++ b/irchelp/clients/unix/erc.md
@@ -1,5 +1,6 @@
 ---
 title: ERC (Emacs IRC Client)
+layout: default
 ---
 
 The text editor and kitchen sink GNU emacs has a obscure, but built-in IRC client in the form of [ERC](http://www.gnu.org/software/emacs/manual/html_mono/erc.html).

--- a/irchelp/clients/unix/scrollz.md
+++ b/irchelp/clients/unix/scrollz.md
@@ -1,5 +1,6 @@
 ---
 title: ScrollZ
+layout: default
 ---
 
 [ScrollZ](http://www.scrollz.com/), offers an ircII like client with extensive script-like features already built in.

--- a/irchelp/clients/unix/weechat.md
+++ b/irchelp/clients/unix/weechat.md
@@ -1,5 +1,6 @@
 ---
 title: weechat
+layout: default
 ---
 
 [WeeChat](www.weechat.org) is a terminal based IRC client. 

--- a/irchelp/clients/webclients.md
+++ b/irchelp/clients/webclients.md
@@ -1,5 +1,6 @@
 ---
 title: Web Clients
+layout: default
 ---
 
 # Overview

--- a/irchelp/clients/windows/bersirc.md
+++ b/irchelp/clients/windows/bersirc.md
@@ -1,5 +1,6 @@
 ---
 title: bersirc
+layout: default
 ---
 
 # Bersirc

--- a/irchelp/clients/windows/index.md
+++ b/irchelp/clients/windows/index.md
@@ -1,5 +1,6 @@
 ---
 title: IRC Clients for Windows
+layout: default
 ---
 
 # IRC Clients for Windows

--- a/irchelp/clients/windows/instantmessage.md
+++ b/irchelp/clients/windows/instantmessage.md
@@ -1,6 +1,7 @@
 ---
 title: IRC with an Instant Messaging program on Windows
 author: Stephanie Daugherty
+layout: default
 ---
 
 # Introduction

--- a/irchelp/clients/windows/unixports.md
+++ b/irchelp/clients/windows/unixports.md
@@ -1,6 +1,7 @@
 ---
 title: Using Linux/Unix Clients on Windows
 author: Stephanie Daugherty
+layout: default
 ---
 
 

--- a/irchelp/clients/windows/xchat.md
+++ b/irchelp/clients/windows/xchat.md
@@ -1,5 +1,6 @@
 ---
 title: XChat
+layout: default
 ---
   
 # XChat

--- a/irchelp/communication-research/academic/academic-reid-e-electropolis-1991.md
+++ b/irchelp/communication-research/academic/academic-reid-e-electropolis-1991.md
@@ -1,6 +1,7 @@
 ---
 title: Electropolis  Communication and Community on Internet Relay Chat
 author: Elizabeth M. Reid
+layout: default
 ---
 
 #### **[IRC Communication Research Resources][1]**

--- a/irchelp/communication-research/academic/index.md
+++ b/irchelp/communication-research/academic/index.md
@@ -1,5 +1,6 @@
 ---
 title: Academic Resources
+layout: default
 ---
 
 #### **IRC Communication Research Resources**

--- a/irchelp/communication-research/index.md
+++ b/irchelp/communication-research/index.md
@@ -1,6 +1,7 @@
 ---
 title: IRC Communications Resarch Resources
 author: E. Sean Rintel
+layout: default
 ---
 
 &nbsp_place_holder;

--- a/irchelp/credit.md
+++ b/irchelp/credit.md
@@ -2,6 +2,7 @@
 title: Credits and Server Information for www.irchelp.org
 author: irchelp.org staff
 summary: A listing of all the people who've helped to bring this site to you over the years.
+layout: default
 ---
 
 # Credits & Server Info for www.irchelp.org

--- a/irchelp/dalnet.md
+++ b/irchelp/dalnet.md
@@ -4,6 +4,7 @@ author: irchelpers
 datechanged: 1 December 2012
 status: historical
 summary: A server list and news for Dalnet
+layout: default
 ---
 
 *Editor's note: This document came about during a period of severe denial of service attacks directed against the DALNet IRC Network, during which EFNet #irchelp was flooded with questions from users that couldn't connect to DALNet.*

--- a/irchelp/faq1irc.md
+++ b/irchelp/faq1irc.md
@@ -1,6 +1,7 @@
 ---
 title: Undernet IRC FAQ Part 1
 author: Paul Grant, Mandar Mirashi
+layout: default
 ---
 
     Summary: This posting contains useful information regarding IRC and an

--- a/irchelp/faq2irc.md
+++ b/irchelp/faq2irc.md
@@ -1,6 +1,7 @@
 ---
 title: Undernet IRC FAQ Part 1
 author: Paul Grant, Mandar Mirashi
+layout: default
 ---
 
 

--- a/irchelp/faqtiny.md
+++ b/irchelp/faqtiny.md
@@ -1,6 +1,7 @@
 ---
 title: A Hitchhiker's Guide to ircII for GAS Users
 status: historical
+layout: default
 ---
 
 A Hitchhiker's Guide to ircII for GAS Users

--- a/irchelp/help.md
+++ b/irchelp/help.md
@@ -1,5 +1,6 @@
 ---
 title: help page for irchelp archive
+layout: default
 ---
 # Help page for #IRChelp archive
 

--- a/irchelp/historic/telnet.md
+++ b/irchelp/historic/telnet.md
@@ -2,6 +2,7 @@
 title: IRC (EFnet) by telnet
 author: Ron Ritzman
 status: historical
+layout: default
 ---
 
 *Editor's Note: This document is outdated, and is retained only for historical interest.*

--- a/irchelp/historic/wsirc.md
+++ b/irchelp/historic/wsirc.md
@@ -1,6 +1,7 @@
 ---
 title: WSIRC
 status: historical
+layout: default
 ---
 
 *Editor's note: The WSIRC mentioned here was an early 1990s IRC client for Windows 3.1 systems, one of the first to be offered for Windows. This client is long obsolete, but the information on it is retained for historical interest.*

--- a/irchelp/ifaq.md
+++ b/irchelp/ifaq.md
@@ -1,5 +1,6 @@
 ---
 title: alt.irc FAQ
+layout: default
 ---
 # The alt.irc IFAQ
 

--- a/irchelp/ircd/alleged.md
+++ b/irchelp/ircd/alleged.md
@@ -1,6 +1,7 @@
 ---
 title: IRCD Help (EFNet #ircd)
 author: Networked
+layout: default
 ---
 
 ##  IRCD Help (EFNet #ircd)

--- a/irchelp/ircd/hybrid/index.md
+++ b/irchelp/ircd/hybrid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ircd-hybrid
 author: irchelp.org staff
+layout: default
 ---
 # hybrid ircd
 

--- a/irchelp/ircd/index.md
+++ b/irchelp/ircd/index.md
@@ -1,6 +1,7 @@
 ---
 title: ircd information
 author: irchelp.org staff
+layout: default
 ---
 
 

--- a/irchelp/ircd/ratbox/index.md
+++ b/irchelp/ircd/ratbox/index.md
@@ -1,6 +1,7 @@
 ---
 title: ircd-ratbox
 author: irchelp.org staff
+layout: default
 ---
 # ratbox ircd
 

--- a/irchelp/ircd/services.md
+++ b/irchelp/ircd/services.md
@@ -1,6 +1,7 @@
 ---
 title: Understanding IRC Services
 author: Stephanie Daugherty
+layout: default
 ---
 
 # Understanding IRC Services

--- a/irchelp/irchelpfaq.md
+++ b/irchelp/irchelpfaq.md
@@ -1,6 +1,7 @@
 ---
 title: The unofficial #irchelp FAQ (ufAQ)
 author: Alex Charalabidis (Apatrix)
+layout: default
 ---
 # The unofficial #irchelp FAQ (uFAQ)
 

--- a/irchelp/ircprimer.md
+++ b/irchelp/ircprimer.md
@@ -1,5 +1,6 @@
 ---
 title: A Short IRC Primer
+layout: default
 ---
 
 _ [ Note: At 93 K in size, this "short" help file is anything but short, and

--- a/irchelp/irctutorial.md
+++ b/irchelp/irctutorial.md
@@ -1,5 +1,6 @@
 ---
 title: An IRC Tutorial
+layout: default
 ---
 
 # An IRC Tutorial

--- a/irchelp/library.md
+++ b/irchelp/library.md
@@ -1,5 +1,6 @@
 ---
 title: Site Map
+layout: default
 ---
 
 ## Site Map

--- a/irchelp/migration.md
+++ b/irchelp/migration.md
@@ -1,6 +1,7 @@
 ---
 title: www.irchelp.org 2012 site redesign and migration
 author: Stephanie Daugherty
+layout: default
 ---
 
 ## Timeline

--- a/irchelp/misc/slack_and_irc.md
+++ b/irchelp/misc/slack_and_irc.md
@@ -1,6 +1,7 @@
 ---
 title: Slack and IRC
 author: Stephanie Daugherty
+layout: default
 ---
 
 # Slack

--- a/irchelp/misc/unixhelp.md
+++ b/irchelp/misc/unixhelp.md
@@ -1,6 +1,7 @@
 ---
 title: Using Linux (and other Unix-like systems) from the command line
 author: irchelp.org staff
+layout: default
 ---
 
 # Using Linux (and other Unix-like systems) from the command line

--- a/irchelp/networks/addreq.md
+++ b/irchelp/networks/addreq.md
@@ -1,6 +1,7 @@
 ---
 title: Adding yourself to our networks list
 author: irchelp.org staff
+layout: default
 ---
 
 # Adding yourself to our networks list

--- a/irchelp/networks/connectprob.md
+++ b/irchelp/networks/connectprob.md
@@ -1,6 +1,7 @@
 ---
 title: IRC Connection Problems
 author: Joseph Lo (jolo)
+layout: default
 ---
 
 # IRC Connection Problems

--- a/irchelp/networks/freenode.md
+++ b/irchelp/networks/freenode.md
@@ -1,6 +1,7 @@
 ---
 title: Freenode
 author: irchelp.org staff
+layout: default
 ---
 
 # freenode

--- a/irchelp/networks/general.md
+++ b/irchelp/networks/general.md
@@ -1,5 +1,6 @@
 ---
 title: General IRC networks
+layout: default
 ---
 
 # General IRC Networks

--- a/irchelp/networks/index.md
+++ b/irchelp/networks/index.md
@@ -1,6 +1,7 @@
 ---
 title: IRC Networks
 author: PhyberBX, Apatrix, and Jolo
+layout: default
 ---
 
 # IRC Networks and Server Lists

--- a/irchelp/networks/ircnet.md
+++ b/irchelp/networks/ircnet.md
@@ -4,6 +4,7 @@ dateupdated: 08 May 2013
 author: Moritz Wilhelmy
 summary: Information about IRCnet as a network
 title: IRCnet
+layout: default
 ---
 # IRCNet
 

--- a/irchelp/networks/noserv.md
+++ b/irchelp/networks/noserv.md
@@ -1,6 +1,7 @@
 ---
 title: Why EFnet/IRCnet has no registration services?
 author: Jolo
+layout: default
 ---
 # Why EFnet/IRCnet has no registration services?
 

--- a/irchelp/networks/popular.md
+++ b/irchelp/networks/popular.md
@@ -1,6 +1,7 @@
 ---
 title: Popular IRC networks
 author: irchelp.org staff
+layout: default
 ---
 
 # Popular IRC Networks

--- a/irchelp/networks/regional.md
+++ b/irchelp/networks/regional.md
@@ -1,5 +1,6 @@
 ---
 title: Regional IRC networks
+layout: default
 ---
 
 # Regional IRC Networks

--- a/irchelp/networks/topical.md
+++ b/irchelp/networks/topical.md
@@ -1,6 +1,7 @@
 ---
 title: Topical IRC networks
 author: irchelp.org staff
+layout: default
 ---
 
 # Special Subject Networks

--- a/irchelp/new2irc.md
+++ b/irchelp/new2irc.md
@@ -1,6 +1,7 @@
 ---
 title: The IRC Prelude
 author: David Caraballo (DC-itsme) and Joseph Lo (Jolo)
+layout: default
 ---
 # The IRC Prelude
 

--- a/irchelp/opguide.md
+++ b/irchelp/opguide.md
@@ -1,6 +1,7 @@
 ---
 title: The Operator's Guide
 status: historical
+layout: default
 ---
 
 **Editor's note**: This is a classic help file dating back to the 1990s when IRC was very new. We still keep this file here for historic value, and also because the general information is still accurate. If you are interested in other, more up to date help files, see [IRC FAQs and Help Files](/irchelp/faq.html). In particular, we completely rewrote this guide to create [The New IRC Channel Operator's Guide](/irchelp/changuide.html) which covers all the information you need to run a stable, successful channel. 

--- a/irchelp/security/linksvbs.md
+++ b/irchelp/security/linksvbs.md
@@ -3,6 +3,7 @@ title: Identification and removal of links.vbs trojan horse
 author: Stephanie Daugherty
 datemodified: 12 Jan 2000
 status: historical
+layout: default
 ---
 *Editor's note: This document pertains to the removal of a trojan horse which most commonly affected Windows 95, Windows 98, Windows ME, and occasional Windows XP systems. Current antimalware software should detect and remove this trojan horse - the instructions below are obsolete and may not work correctly on more modern operating systems.*
 


### PR DESCRIPTION
This makes them use the default layout, when used with #34 this lets a lot more files get displayed properly.

The YAML front-matter still needs to be added for a bunch of files (and a lot of .md files are empty -- to be migrated over to .md from other formats?), but I figure that can be done in a separate PR since it's more in-depth work than just adding the `layout` key.