### PR TITLE
Fix regressions in navbar and fix other broken/redirected links.

### DIFF
--- a/_includes/helpstrap_navbar.html
+++ b/_includes/helpstrap_navbar.html
@@ -8,7 +8,7 @@
           <div class="nav-collapse collapse">
             <ul class="nav">
               <li class="active"><a href="/">Home</a></li>
-              <li><a href="/credit.html">About</a></li>
+              <li><a href="/irchelp/credit.html">About</a></li>
               <li class="dropdown"> <a href="/clients" class="dropdown-toggle"
                   data-toggle="dropdown">Clients </a>
                 <ul class="dropdown-menu">
@@ -16,7 +16,7 @@
                   <li class="divider"></li>
                   <li class="nav-header">Windows</li>
                   <li><a href="/clients/windows/mirc">mIRC</a></li>
-                  <li><a href="/clients/windows/xchat">XChat</a></li>
+                  <li><a href="/clients/unix/xchat">XChat</a></li>
                   <li><a href="/clients/windows">All Windows Clients</a></li>
                   <li class="divider"></li>
                   <li class="nav-header">MacOS X</li>
@@ -32,16 +32,15 @@
                   <li><a href="/clients/unix/index.html#terminal">All Linux/Unix Terminal Clients</a></li>
                   <li class="divider"></li>
                   <li class="nav-header">Linux/Unix Graphical</li>
-                  <li><a href="/clients/unix/xchat.html">XChat</a></li>
+                  <li><a href="/clients/unix/xchat">XChat</a></li>
                   <li><a href="/clients/unix/konversation.html">Konversation</a></li>
-                  <li><a href="/clients/unix/index.html#gui">All Linux/Unix Graphical Clients</a></li>
+                  <li><a href="/clients/unix/index.html#x11-graphical">All Linux/Unix Graphical Clients</a></li>
                   <li class="nav-header">Smartphones</li>
                   <li><a href="/clients/mobile/android">Clients for Android</a></li>
                   <li><a href="/clients/mobile/ios">Clients for iOS</a></li>
                   <li><a href="/clients/mobile">All Smartphone Clients</a></li>
                   <li class="nav-header">Other OS and Crossplatform</li>
-                  <li><a href="/clients/cross/java">Clients writting in Java</a></li>
-                  <li><a href="/clients/cross">Other Crossplatform Clients</a></li>
+                  <li><a href="/clients/cross">Crossplatform Clients</a></li>
                   <li><a href="/clients/otheros">Clients for other Operating Systems</a></li>
                   <li><a href="/clients/webclients.html">Web-based clients</a></li>
 
@@ -53,7 +52,7 @@
                   <li><a href="/networks/popular.html">Major Networks</a></li>
                   <li><a href="/networks/regional.html">Regional Networks</a></li>
                   <li><a href="/networks/topical.html">Topical Networks</a></li>
-                  <li><a href="/networks>All Networks</a></li>
+                  <li><a href="/networks">All Networks</a></li>
                   <li class="divider"></li>
                   <li class="nav-header">Major Networks</li>
                   <li><a href="/networks/efnet/">EFNet</a></li>
@@ -69,7 +68,7 @@
                 <ul class="dropdown-menu">
                   <li><a href="/security">General Security</a></li>
                   <li><a href="/security/privacy.html">Privacy</a></li>
-                  <li><a href="/security/nuke.html">Denial of Service</a></li>
+                  <li><a href="/nuke">Denial of Service</a></li>
                   <li><a href="/security/trojan.html">Trojan Horses and Other Malware</a></li>
                   <li><a href="/security/socialeng.html">Social Engineering</a></li>
                 </ul>
@@ -87,7 +86,7 @@
               <li class="dropdown"> <a href="/faq/new2irc.html" class="dropdown-toggle"
                   data-toggle="dropdown">FAQs </a>
                 <ul class="dropdown-menu">
-                  <li><a href="/new2irc.html">New user introduction</a></li>
+                  <li><a href="/faq/new2irc.html">New user introduction</a></li>
 <!--
                   <li><a href="#">Another action</a></li>
                   <li><a href="#">Something else here</a></li>
@@ -98,10 +97,10 @@
 -->
                 </ul>
               </li>
-              <li class="dropdown"> <a href="/library.html" class="dropdown-toggle"
+              <li class="dropdown"> <a href="/irchelp/library.html" class="dropdown-toggle"
                   data-toggle="dropdown">Library </a>
                 <ul class="dropdown-menu">
-                  <li><a href="/library.html">Index</a></li>
+                  <li><a href="/irchelp/library.html">Index</a></li>
 <!--
                   <li><a href="#">Another action</a></li>
                   <li><a href="#">Something else here</a></li>


### PR DESCRIPTION
This should fix all the warnings in the navbar (which is 2322 of the 2730 link warnings in the log due to repeating 258 times)

After taking a closer look at the other warnings, there are quite a lot of content issues; I can see a path to fixing 20-40% of them in an automated fashion. I might be able to build some logic that could find relocated files to improve that.